### PR TITLE
Add supported languages to Mutator creation

### DIFF
--- a/stryker4jvm/src/main/scala/stryker4jvm/mutants/SupportedLanguageMutators.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/mutants/SupportedLanguageMutators.scala
@@ -11,7 +11,9 @@ object SupportedLanguageMutators {
     SupportedMutator("kotlin", "kt", new KotlinMutator())
   )
 
-  def languageRouter: Map[String, LanguageMutator[? <: AST]] = supportedMutators.map(mutator => (mutator.extension -> mutator.languageMutator)).toMap
+  def languageRouter: Map[String, LanguageMutator[? <: AST]] =
+    supportedMutators.map(mutator => mutator.extension -> mutator.languageMutator).toMap
 
-  def mutatesFileSources: Seq[String] = supportedMutators.map(mutator => s"**/main/${mutator.directory}/**.${mutator.extension}")
+  def mutatesFileSources: Seq[String] =
+    supportedMutators.map(mutator => s"**/main/${mutator.directory}/**.${mutator.extension}")
 }

--- a/stryker4jvm/src/main/scala/stryker4jvm/mutants/SupportedLanguageMutators.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/mutants/SupportedLanguageMutators.scala
@@ -1,0 +1,17 @@
+package stryker4jvm.mutants
+
+import stryker4jvm.core.model.LanguageMutator
+import stryker4jvm.core.model.AST
+import stryker4jvm.mutator.kotlin.KotlinMutator
+
+case class SupportedMutator(directory: String, extension: String, languageMutator: LanguageMutator[? <: AST])
+
+object SupportedLanguageMutators {
+  val supportedMutators: Array[SupportedMutator] = Array(
+    SupportedMutator("kotlin", "kt", new KotlinMutator())
+  )
+
+  def languageRouter: Map[String, LanguageMutator[? <: AST]] = supportedMutators.map(mutator => (mutator.extension -> mutator.languageMutator)).toMap
+
+  def mutatesFileSources: Seq[String] = supportedMutators.map(mutator => s"**/main/${mutator.directory}/**.${mutator.extension}")
+}

--- a/stryker4jvm/src/main/scala/stryker4jvm/run/Stryker4jvmRunner.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/run/Stryker4jvmRunner.scala
@@ -10,24 +10,17 @@ import stryker4jvm.core.logging.Logger
 import stryker4jvm.files.{ConfigFilesResolver, FilesFileResolver, GlobFileResolver, MutatesFileResolver}
 import stryker4jvm.logging.SttpLogWrapper
 import stryker4jvm.model.CompilerErrMsg
-import stryker4jvm.mutants.Mutator
-import stryker4jvm.mutator.scala.mutants.tree.{InstrumenterOptions, MutantCollector, MutantInstrumenter}
-import stryker4jvm.reporting.dashboard.DashboardConfigProvider
+import stryker4jvm.mutants.{Mutator, SupportedLanguageMutators}
+import stryker4jvm.mutator.scala.mutants.tree.InstrumenterOptions
 import stryker4jvm.reporting.*
-import stryker4jvm.reporting.reporters.{
-  AggregateReporter,
-  ConsoleReporter,
-  DashboardReporter,
-  HtmlReporter,
-  JsonReporter
-}
+import stryker4jvm.reporting.dashboard.DashboardConfigProvider
+import stryker4jvm.reporting.reporters.*
 import stryker4jvm.run.process.ProcessRunner
 import stryker4jvm.run.threshold.ScoreStatus
 import sttp.client3.SttpBackend
 import sttp.client3.httpclient.fs2.HttpClientFs2Backend
 import sttp.client3.logging.LoggingBackend
 import sttp.model.HeaderNames
-import stryker4jvm.mutants.SupportedLanguageMutators
 
 abstract class Stryker4jvmRunner(implicit log: Logger) {
   def run(): IO[ScoreStatus] = {

--- a/stryker4jvm/src/main/scala/stryker4jvm/run/Stryker4jvmRunner.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/run/Stryker4jvmRunner.scala
@@ -27,6 +27,7 @@ import sttp.client3.SttpBackend
 import sttp.client3.httpclient.fs2.HttpClientFs2Backend
 import sttp.client3.logging.LoggingBackend
 import sttp.model.HeaderNames
+import stryker4jvm.mutants.SupportedLanguageMutators
 
 abstract class Stryker4jvmRunner(implicit log: Logger) {
   def run(): IO[ScoreStatus] = {
@@ -39,10 +40,7 @@ abstract class Stryker4jvmRunner(implicit log: Logger) {
     val stryker4jvm = new Stryker4jvm(
       resolveMutatesFileSource,
       new Mutator(
-        Map.empty
-//        new MutantFinder(),
-//        new MutantCollector(new TraverserImpl(), new MutantMatcherImpl()),
-//        new MutantInstrumenter(instrumenterOptions)
+        SupportedLanguageMutators.languageRouter
       ),
       new MutantRunner(createTestRunnerPool, resolveFilesFileSource, new RollbackHandler(), reporter),
       reporter
@@ -90,7 +88,7 @@ abstract class Stryker4jvmRunner(implicit log: Logger) {
   def resolveMutatesFileSource(implicit config: Config): MutatesFileResolver =
     new GlobFileResolver(
       config.baseDir,
-      if (config.mutate.nonEmpty) config.mutate else Seq("**/main/scala/**.scala")
+      if (config.mutate.nonEmpty) config.mutate else SupportedLanguageMutators.mutatesFileSources
     )
 
   def resolveFilesFileSource(implicit config: Config): FilesFileResolver = new ConfigFilesResolver(ProcessRunner())


### PR DESCRIPTION
Mutator was initially not created with supported languages. This commit aims to provide a simple way to add language mutator, for both the directory Stryker4jvm searches for and the language mutator corresponding to the language.