### PR TITLE
Fix stryker4jvm broken dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,26 @@ See the [releases page](https://github.com/stryker-mutator/stryker4s/releases) f
 ## Contributing
 
 Want to contribute? That's great! Please have a look at our [contributing guide](https://stryker-mutator.io/docs/stryker4s/contributing).
+
+Developing on stryker4jvm:
+Currently, stryker4jvm is using 3 build tools for all its modules. Stryker4jvm-core is managed by maven,
+stryker4jvm-mutator-kotlin is managed by gradle and all other modules are managed by sbt. In order to build/test locally
+you need to take the following steps:
+1) Building stryker4jvm-core:
+   1) cd to stryker4jvm-core root
+   2) mvn clean
+   3) mvn install
+2) Building stryker4jvm-mutator-kotlin:
+   1) Verify version of gradle daemon by running ./gradlew --version in the root of mutator kotlin module.
+   The JVM version should be 15 (theoretically, 11 should also work but has not been tested). Furthermore, it should say
+   kotlin version 1.4.20. Build has only been confirmed to work with gradle 6.9.1, kotlin 1.4.20, groovy 2.5.12 and jvm 15.0.2.
+   In order to change the JVM version to use, either change your JAVA_HOME environment variable or specify the version to use
+   for gradle for commands like so: "./gradlew \<command> -Dorg.gradle.java.home=/JDK_PATH".
+   2) Delete the .gradle folder and build folder in module root if there were version issues or gradle build errors. Note that
+   if you changed versions, you may need to restart your computer entirely.
+   3) ./gradlew clean build
+   4) ./gradlew publishToMavenLocal
+3) Building all other sbt modules:
+    1) cd to project root (should contain build.sbt file)
+    2) sbt compile (if you wish to only compile a specific module, use sbt <module-name>/compile)
+    3) sbt test (optional)

--- a/stryker4jvm-core/src/main/java/stryker4jvm/core/model/Collector.java
+++ b/stryker4jvm-core/src/main/java/stryker4jvm/core/model/Collector.java
@@ -8,5 +8,5 @@ public interface Collector<T extends AST> {
      * @param tree The source
      * @return A {@link CollectedMutants collection} of mutants.
      */
-    CollectedMutants<T> collect(T tree, LanguageMutatorConfig config);
+    CollectedMutants<T> collect(T tree);
 }

--- a/stryker4jvm-core/src/main/java/stryker4jvm/core/model/Instrumenter.java
+++ b/stryker4jvm-core/src/main/java/stryker4jvm/core/model/Instrumenter.java
@@ -14,4 +14,30 @@ public interface Instrumenter<T extends AST> {
      */
     T instrument(T source, Map<T, List<MutantWithId<T>>> mutations,
         LanguageMutatorConfig config);
+
+    default void f() {
+        System.getProperty("");
+        java.lang.System.getenv("");
+    }
+
+    enum InstrumenterOptions {
+        /**
+         * The active mutation can be found under System properties with {@link #KEY}.
+         */
+        SysProp,
+        /**
+         * The active mutation can be found under System environment variables with {@link #KEY}
+         */
+        EnvVar,
+        /**
+         * Unclear what this does exactly. I believe that this allows the instrumenter to refer to a static
+         * field of a certain class that is dynamically being updated between runs. Additionally, it has some kind
+         * of conditional filter which is unclear why it has that.
+         */
+        TestRunner;
+        /**
+         * The key for system properties and environment variables
+         */
+        public static final String KEY = "ACTIVE_MUTATION";
+    }
 }

--- a/stryker4jvm-core/src/main/java/stryker4jvm/core/model/Instrumenter.java
+++ b/stryker4jvm-core/src/main/java/stryker4jvm/core/model/Instrumenter.java
@@ -12,32 +12,5 @@ public interface Instrumenter<T extends AST> {
      * @param mutations The mutations to instrument into the source.
      * @return A new AST instance which has the mutations included in its structure.
      */
-    T instrument(T source, Map<T, List<MutantWithId<T>>> mutations,
-        LanguageMutatorConfig config);
-
-    default void f() {
-        System.getProperty("");
-        java.lang.System.getenv("");
-    }
-
-    enum InstrumenterOptions {
-        /**
-         * The active mutation can be found under System properties with {@link #KEY}.
-         */
-        SysProp,
-        /**
-         * The active mutation can be found under System environment variables with {@link #KEY}
-         */
-        EnvVar,
-        /**
-         * Unclear what this does exactly. I believe that this allows the instrumenter to refer to a static
-         * field of a certain class that is dynamically being updated between runs. Additionally, it has some kind
-         * of conditional filter which is unclear why it has that.
-         */
-        TestRunner;
-        /**
-         * The key for system properties and environment variables
-         */
-        public static final String KEY = "ACTIVE_MUTATION";
-    }
+    T instrument(T source, Map<T, List<MutantWithId<T>>> mutations);
 }

--- a/stryker4jvm-core/src/main/java/stryker4jvm/core/model/InstrumenterOptions.java
+++ b/stryker4jvm-core/src/main/java/stryker4jvm/core/model/InstrumenterOptions.java
@@ -1,0 +1,24 @@
+package stryker4jvm.core.model;
+
+public enum InstrumenterOptions {
+    /**
+     * The active mutation can be found under System properties with {@link #KEY}. The value may be updated
+     * dynamically at runtime.
+     */
+    SysProp,
+    /**
+     * The active mutation can be found under System environment variables with {@link #KEY}. This is a constant
+     * value that cannot change during runtime.
+     */
+    EnvVar,
+    /**
+     * Unclear what this does exactly. I believe that this allows the instrumenter to refer to a static
+     * field of a certain class that is dynamically being updated between runs. Additionally, it has some kind
+     * of conditional filter which is unclear why it has that.
+     */
+    TestRunner;
+    /**
+     * The key for system properties and environment variables
+     */
+    public static final String KEY = "ACTIVE_MUTATION";
+}

--- a/stryker4jvm-core/src/main/java/stryker4jvm/core/model/LanguageMutator.java
+++ b/stryker4jvm-core/src/main/java/stryker4jvm/core/model/LanguageMutator.java
@@ -14,7 +14,6 @@ public class LanguageMutator<T extends AST> {
     private final Parser<T> parser;
     private final Collector<T> collector;
     private final Instrumenter<T> instrumenter;
-    private LanguageMutatorConfig languageConfig;
 
     public LanguageMutator(Parser<T> parser, Collector<T> collector, Instrumenter<T> instrumenter) {
         this.parser = parser;
@@ -22,22 +21,15 @@ public class LanguageMutator<T extends AST> {
         this.instrumenter = instrumenter;
     }
 
-    public void setLanguageConfig(LanguageMutatorConfig config) {
-        this.languageConfig = config;
-    }
-
     public T parse(Path p) throws IOException {
-        return parser.parse(p, languageConfig);
+        return parser.parse(p);
     }
 
     public CollectedMutants<T> collect(AST tree) {
-        return collector.collect((T) tree, languageConfig);
+        return collector.collect((T) tree);
     }
 
     public T instrument(AST source, Map<AST, List<MutantWithId<AST>>> mutations) {
-        return instrumenter.instrument((T) source,
-            (Map<T, List<MutantWithId<T>>>) (Map<T, ?>) mutations,
-            languageConfig
-        );
+        return instrumenter.instrument((T) source, (Map<T, List<MutantWithId<T>>>) (Map<T, ?>) mutations);
     }
 }

--- a/stryker4jvm-core/src/main/java/stryker4jvm/core/model/Parser.java
+++ b/stryker4jvm-core/src/main/java/stryker4jvm/core/model/Parser.java
@@ -12,5 +12,5 @@ public interface Parser<T extends AST> {
      * @return An appropriate AST
      * @throws IOException when the file could not be parsed into an AST. todo: IOException should be replaced with a parse exception
      */
-    T parse(Path p, LanguageMutatorConfig config) throws IOException;
+    T parse(Path p) throws IOException;
 }

--- a/stryker4jvm-core/src/main/java/stryker4jvm/core/model/languagemutator/LanguageMutatorProvider.java
+++ b/stryker4jvm-core/src/main/java/stryker4jvm/core/model/languagemutator/LanguageMutatorProvider.java
@@ -1,0 +1,18 @@
+package stryker4jvm.core.model.languagemutator;
+
+import stryker4jvm.core.config.LanguageMutatorConfig;
+import stryker4jvm.core.model.InstrumenterOptions;
+import stryker4jvm.core.model.LanguageMutator;
+
+/**
+ * Factory-like interface for creating language mutators.
+ */
+public interface LanguageMutatorProvider {
+    /**
+     * Factory method that should return a mutator that is constrained by the config and instrumenter options.
+     * @param config The configuration.
+     * @param instrumenterOptions The instrumenter options.
+     * @return A LanguageMutator abiding to the provided configuration and options.
+     */
+    LanguageMutator<?> provideMutator(LanguageMutatorConfig config, InstrumenterOptions instrumenterOptions);
+}

--- a/stryker4jvm-mutator-kotlin/src/main/kotlin/stryker4jvm/mutator/kotlin/KotlinCollector.kt
+++ b/stryker4jvm-mutator-kotlin/src/main/kotlin/stryker4jvm/mutator/kotlin/KotlinCollector.kt
@@ -10,15 +10,9 @@ import stryker4jvm.mutator.kotlin.utility.PsiUtility
 
 class KotlinCollector(private val mutators: Array<out Mutator<*>>) : Collector<KotlinAST> {
 
-    constructor() : this(
-            arrayOf(
-                    BooleanLiteralMutator,
-                    StringLiteralMutator,
-                    EqualityOperatorMutator,
-                    ConditionalExpressionMutator,
-                    LogicalOperatorMutator))
+    constructor() : this(listAllMutators())
 
-    override fun collect(tree: KotlinAST?, config: LanguageMutatorConfig?): CollectedMutants<KotlinAST> {
+    override fun collect(tree: KotlinAST?): CollectedMutants<KotlinAST> {
         if (tree == null)
             return CollectedMutants()
 
@@ -47,7 +41,21 @@ class KotlinCollector(private val mutators: Array<out Mutator<*>>) : Collector<K
         return res
     }
 
-    fun collect(tree: KotlinAST?): CollectedMutants<KotlinAST> {
-        return collect(tree, null)
+    companion object {
+        fun listAllMutators() : Array<out Mutator<*>> {
+            return arrayOf(
+                    BooleanLiteralMutator,
+                    StringLiteralMutator,
+                    EqualityOperatorMutator,
+                    ConditionalExpressionMutator,
+                    LogicalOperatorMutator)
+        }
+
+        fun apply(config: LanguageMutatorConfig) : KotlinCollector {
+            val mutators = listAllMutators().toSet().filter { mutator ->
+                !config.excludedMutations.contains(mutator.name)
+            }
+            return KotlinCollector(mutators.toTypedArray())
+        }
     }
 }

--- a/stryker4jvm-mutator-kotlin/src/main/kotlin/stryker4jvm/mutator/kotlin/KotlinInstrumenterOptions.kt
+++ b/stryker4jvm-mutator-kotlin/src/main/kotlin/stryker4jvm/mutator/kotlin/KotlinInstrumenterOptions.kt
@@ -1,0 +1,17 @@
+package stryker4jvm.mutator.kotlin
+
+import stryker4jvm.core.model.InstrumenterOptions
+
+class KotlinInstrumenterOptions(options: InstrumenterOptions) {
+    val whenExpression: String
+
+    init {
+        val key = InstrumenterOptions.KEY
+        whenExpression = when (options) {
+            InstrumenterOptions.EnvVar -> "when(System.getenv(\"$key\") ?: null)"
+            InstrumenterOptions.SysProp -> "when(System.getProperty(\"$key\") ?: null)"
+            InstrumenterOptions.TestRunner -> throw RuntimeException("Not implemented for test runner!")
+            else -> throw RuntimeException("Not implemented for $options")
+        }
+    }
+}

--- a/stryker4jvm-mutator-kotlin/src/main/kotlin/stryker4jvm/mutator/kotlin/KotlinMutatorProvider.kt
+++ b/stryker4jvm-mutator-kotlin/src/main/kotlin/stryker4jvm/mutator/kotlin/KotlinMutatorProvider.kt
@@ -1,0 +1,18 @@
+package stryker4jvm.mutator.kotlin
+
+import stryker4jvm.core.config.LanguageMutatorConfig
+import stryker4jvm.core.model.InstrumenterOptions
+import stryker4jvm.core.model.LanguageMutator
+import stryker4jvm.core.model.languagemutator.LanguageMutatorProvider
+
+class KotlinMutatorProvider : LanguageMutatorProvider {
+
+    override fun provideMutator(config: LanguageMutatorConfig, options: InstrumenterOptions) : LanguageMutator<KotlinAST> {
+
+        return KotlinMutator(
+                KotlinParser(),
+                KotlinCollector.apply(config),
+                KotlinInstrumenter(options)
+        );
+    }
+}

--- a/stryker4jvm-mutator-kotlin/src/main/kotlin/stryker4jvm/mutator/kotlin/KotlinParser.kt
+++ b/stryker4jvm-mutator-kotlin/src/main/kotlin/stryker4jvm/mutator/kotlin/KotlinParser.kt
@@ -7,11 +7,7 @@ import java.nio.file.Path
 
 class KotlinParser : Parser<KotlinAST> {
 
-    override fun parse(path: Path?, config: LanguageMutatorConfig?): KotlinAST {
+    override fun parse(path: Path?): KotlinAST {
         return KotlinAST(PsiUtility.createPsiFile(java.nio.file.Files.readString(path)))
-    }
-
-    fun parse(path: Path?): KotlinAST {
-        return parse(path, null)
     }
 }

--- a/stryker4jvm-mutator-kotlin/src/test/kotlin/stryker4jvm/mutator/kotlin/InstrumenterTest.kt
+++ b/stryker4jvm-mutator-kotlin/src/test/kotlin/stryker4jvm/mutator/kotlin/InstrumenterTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.*
 
 class InstrumenterTest {
 
-        @Test
+    @Test
     fun shouldReplace() {
         val file = PsiUtility.createPsiFile("val x = true")
         val `true` = PsiUtility.findElementsInFile(file, KtConstantExpression::class.java)
@@ -53,6 +53,5 @@ class InstrumenterTest {
         assertTrue(mutatedText.contains("\"1\" -> true"))
         assertTrue(mutatedText.contains("else -> false"))
         assertFalse(mutatedText.contains("\"1\" -> false"))
-
     }
 }

--- a/stryker4jvm-mutator-kotlin/src/test/kotlin/stryker4jvm/mutator/kotlin/KotlinInstrumenterOptionsTest.kt
+++ b/stryker4jvm-mutator-kotlin/src/test/kotlin/stryker4jvm/mutator/kotlin/KotlinInstrumenterOptionsTest.kt
@@ -1,0 +1,32 @@
+package stryker4jvm.mutator.kotlin
+
+import stryker4jvm.core.model.InstrumenterOptions
+import java.lang.Exception
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KotlinInstrumenterOptionsTest {
+
+    @Test
+    fun shouldProduceWhenWithEnvironmentVariable() {
+        val options = KotlinInstrumenterOptions(InstrumenterOptions.EnvVar)
+        assertTrue(options.whenExpression.contains("getenv"))
+        assertFalse(options.whenExpression.contains("getProperty"))
+    }
+
+    @Test
+    fun shouldProduceWhenWithSystemProperty() {
+        val options = KotlinInstrumenterOptions(InstrumenterOptions.SysProp)
+        assertTrue(options.whenExpression.contains("getProperty"))
+        assertFalse(options.whenExpression.contains("getenv"))
+    }
+
+    @Test
+    fun shouldProduceException() {
+        assertFailsWith<Exception> {
+            KotlinInstrumenterOptions(InstrumenterOptions.TestRunner)
+        }
+    }
+}

--- a/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaCollector.scala
+++ b/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaCollector.scala
@@ -1,11 +1,10 @@
 package stryker4jvm.mutator.scala
 
-import stryker4jvm.core.config.LanguageMutatorConfig
 import stryker4jvm.core.model.Collector
 import stryker4jvm.core.model.CollectedMutants
 
 class ScalaCollector extends Collector[ScalaAST] {
 
-  override def collect(ast: ScalaAST, config: LanguageMutatorConfig): CollectedMutants[ScalaAST] = ???
+  override def collect(ast: ScalaAST): CollectedMutants[ScalaAST] = ???
 
 }

--- a/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaCollector.scala
+++ b/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaCollector.scala
@@ -1,10 +1,11 @@
 package stryker4jvm.mutator.scala
 
+import stryker4jvm.core.config.LanguageMutatorConfig
 import stryker4jvm.core.model.Collector
 import stryker4jvm.core.model.CollectedMutants
 
 class ScalaCollector extends Collector[ScalaAST] {
 
-  override def collect(x$1: ScalaAST): CollectedMutants[ScalaAST] = ???
+  override def collect(ast: ScalaAST, config: LanguageMutatorConfig): CollectedMutants[ScalaAST] = ???
 
 }

--- a/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaInstrumenter.scala
+++ b/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaInstrumenter.scala
@@ -1,9 +1,11 @@
 package stryker4jvm.mutator.scala
 
+import stryker4jvm.core.config.LanguageMutatorConfig
 import stryker4jvm.core.model.Instrumenter
+
 import java.util as ju
 import stryker4jvm.core.model.MutantWithId
 
 class ScalaInstrumenter extends Instrumenter[ScalaAST] {
-  override def instrument(x$1: ScalaAST, x$2: ju.Map[ScalaAST, ju.List[MutantWithId[ScalaAST]]]): ScalaAST = ???
+  override def instrument(ast: ScalaAST, mutations: ju.Map[ScalaAST, ju.List[MutantWithId[ScalaAST]]], config: LanguageMutatorConfig): ScalaAST = ???
 }

--- a/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaInstrumenter.scala
+++ b/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaInstrumenter.scala
@@ -1,11 +1,10 @@
 package stryker4jvm.mutator.scala
 
-import stryker4jvm.core.config.LanguageMutatorConfig
 import stryker4jvm.core.model.Instrumenter
 
 import java.util as ju
 import stryker4jvm.core.model.MutantWithId
 
 class ScalaInstrumenter extends Instrumenter[ScalaAST] {
-  override def instrument(ast: ScalaAST, mutations: ju.Map[ScalaAST, ju.List[MutantWithId[ScalaAST]]], config: LanguageMutatorConfig): ScalaAST = ???
+  override def instrument(ast: ScalaAST, mutations: ju.Map[ScalaAST, ju.List[MutantWithId[ScalaAST]]]): ScalaAST = ???
 }

--- a/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaMutatorProvider.scala
+++ b/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaMutatorProvider.scala
@@ -5,6 +5,8 @@ import stryker4jvm.core.model.{InstrumenterOptions, LanguageMutator}
 import stryker4jvm.core.model.languagemutator.LanguageMutatorProvider
 
 class ScalaMutatorProvider extends LanguageMutatorProvider {
-  override def provideMutator(languageMutatorConfig: LanguageMutatorConfig,
-                              instrumenterOptions: InstrumenterOptions): LanguageMutator[ScalaAST] = ???
+  override def provideMutator(
+      languageMutatorConfig: LanguageMutatorConfig,
+      instrumenterOptions: InstrumenterOptions
+  ): LanguageMutator[ScalaAST] = ???
 }

--- a/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaMutatorProvider.scala
+++ b/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaMutatorProvider.scala
@@ -1,0 +1,10 @@
+package stryker4jvm.mutator.scala
+
+import stryker4jvm.core.config.LanguageMutatorConfig
+import stryker4jvm.core.model.{InstrumenterOptions, LanguageMutator}
+import stryker4jvm.core.model.languagemutator.LanguageMutatorProvider
+
+class ScalaMutatorProvider extends LanguageMutatorProvider {
+  override def provideMutator(languageMutatorConfig: LanguageMutatorConfig,
+                              instrumenterOptions: InstrumenterOptions): LanguageMutator[ScalaAST] = ???
+}

--- a/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaParser.scala
+++ b/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaParser.scala
@@ -1,11 +1,10 @@
 package stryker4jvm.mutator.scala
 
-import stryker4jvm.core.config.LanguageMutatorConfig
 import stryker4jvm.core.model.Parser
 
 import java.nio.file.Path
 
 class ScalaParser extends Parser[ScalaAST] {
 
-  override def parse(file: Path, config: LanguageMutatorConfig): ScalaAST = ???
+  override def parse(file: Path): ScalaAST = ???
 }

--- a/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaParser.scala
+++ b/stryker4jvm-new-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaParser.scala
@@ -1,9 +1,11 @@
 package stryker4jvm.mutator.scala
 
+import stryker4jvm.core.config.LanguageMutatorConfig
 import stryker4jvm.core.model.Parser
+
 import java.nio.file.Path
 
 class ScalaParser extends Parser[ScalaAST] {
 
-  override def parse(x$1: Path): ScalaAST = ???
+  override def parse(file: Path, config: LanguageMutatorConfig): ScalaAST = ???
 }

--- a/stryker4jvm/src/main/scala/stryker4jvm/config/pure/ConfigConfigReader.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/config/pure/ConfigConfigReader.scala
@@ -30,16 +30,16 @@ trait ConfigConfigReader {
   implicit def exclusionsReader: ConfigReader[Config.ExcludedMutations] =
     ConfigReader[List[String]] emap { exclusions =>
       exclusions.toSet.asRight
-      // todo: This validation should be done by the language specific implementations!
-      //      val (valid, invalid) = exclusions.partition(Mutation.mutations.contains)
-      //      if (invalid.nonEmpty)
-      //        CannotConvert(
-      //          exclusions.mkString(", "),
-      //          s"excluded-mutations",
-      //          s"invalid option(s) '${invalid.mkString(", ")}'. Valid exclusions are '${Mutation.mutations.mkString(", ")}'"
-      //        ).asLeft
-      //      else
-      //        valid.toSet.asRight
+    // todo: This validation should be done by the language specific implementations!
+    //      val (valid, invalid) = exclusions.partition(Mutation.mutations.contains)
+    //      if (invalid.nonEmpty)
+    //        CannotConvert(
+    //          exclusions.mkString(", "),
+    //          s"excluded-mutations",
+    //          s"invalid option(s) '${invalid.mkString(", ")}'. Valid exclusions are '${Mutation.mutations.mkString(", ")}'"
+    //        ).asLeft
+    //      else
+    //        valid.toSet.asRight
     }
 
   implicit def uriReader: ConfigReader[Uri] = _root_.pureconfig.module.sttp.reader
@@ -90,8 +90,8 @@ trait ConfigConfigReader {
         val invalidDialectString =
           s"Leaving this configuration empty defaults to scala213source3 which might also work for you. Valid scalaDialects are: " +
             s"${scalaVersions.keys.flatten
-              .map(d => s"'$d'")
-              .mkString(", ")}"
+                .map(d => s"'$d'")
+                .mkString(", ")}"
         CannotConvert(input, "scala-dialect", s"$msg. $invalidDialectString")
       }
 

--- a/stryker4jvm/src/main/scala/stryker4jvm/config/pure/ConfigConfigReader.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/config/pure/ConfigConfigReader.scala
@@ -5,8 +5,7 @@ import fs2.io.file.Path
 import pureconfig.ConfigReader
 import pureconfig.error.CannotConvert
 import pureconfig.generic.semiauto.*
-import stryker4jvm.mutator.scala.config.*
-import stryker4jvm.mutator.scala.extensions.mutationtype.Mutation
+import stryker4jvm.config.*
 import sttp.model.Uri
 
 import java.nio.file.Path as JPath
@@ -30,15 +29,17 @@ trait ConfigConfigReader {
 
   implicit def exclusionsReader: ConfigReader[Config.ExcludedMutations] =
     ConfigReader[List[String]] emap { exclusions =>
-      val (valid, invalid) = exclusions.partition(Mutation.mutations.contains)
-      if (invalid.nonEmpty)
-        CannotConvert(
-          exclusions.mkString(", "),
-          s"excluded-mutations",
-          s"invalid option(s) '${invalid.mkString(", ")}'. Valid exclusions are '${Mutation.mutations.mkString(", ")}'"
-        ).asLeft
-      else
-        valid.toSet.asRight
+      exclusions.toSet.asRight
+      // todo: This validation should be done by the language specific implementations!
+      //      val (valid, invalid) = exclusions.partition(Mutation.mutations.contains)
+      //      if (invalid.nonEmpty)
+      //        CannotConvert(
+      //          exclusions.mkString(", "),
+      //          s"excluded-mutations",
+      //          s"invalid option(s) '${invalid.mkString(", ")}'. Valid exclusions are '${Mutation.mutations.mkString(", ")}'"
+      //        ).asLeft
+      //      else
+      //        valid.toSet.asRight
     }
 
   implicit def uriReader: ConfigReader[Uri] = _root_.pureconfig.module.sttp.reader
@@ -89,8 +90,8 @@ trait ConfigConfigReader {
         val invalidDialectString =
           s"Leaving this configuration empty defaults to scala213source3 which might also work for you. Valid scalaDialects are: " +
             s"${scalaVersions.keys.flatten
-                .map(d => s"'$d'")
-                .mkString(", ")}"
+              .map(d => s"'$d'")
+              .mkString(", ")}"
         CannotConvert(input, "scala-dialect", s"$msg. $invalidDialectString")
       }
 

--- a/stryker4jvm/src/main/scala/stryker4jvm/extensions/Stryker4jvmCoreConversions.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/extensions/Stryker4jvmCoreConversions.scala
@@ -110,6 +110,6 @@ object Stryker4jvmCoreConversions {
 
   implicit final class ConfigExtension(config: Config) {
     implicit def asLanguageMutatorConfig: LanguageMutatorConfig =
-      new LanguageMutatorConfig((config.excludedMutations.asInstanceOf[Set[String]]).asJava)
+      new LanguageMutatorConfig(config.excludedMutations.asJava)
   }
 }

--- a/stryker4jvm/src/main/scala/stryker4jvm/mutants/SupportedLanguageMutators.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/mutants/SupportedLanguageMutators.scala
@@ -6,11 +6,14 @@ import stryker4jvm.core.model.languagemutator.LanguageMutatorProvider
 import stryker4jvm.mutator.kotlin.KotlinMutatorProvider
 import stryker4jvm.mutator.scala.ScalaMutatorProvider
 
-case class SupportedProvider(name: String, directory: String, extension: String, languageProvider: LanguageMutatorProvider) {
-  def provideMutator(
-                      config: LanguageMutatorConfig,
-                      options: InstrumenterOptions):
-  LanguageMutator[? <: AST] = languageProvider.provideMutator(config, options).asInstanceOf[LanguageMutator[? <: AST]]
+case class SupportedProvider(
+    name: String,
+    directory: String,
+    extension: String,
+    languageProvider: LanguageMutatorProvider
+) {
+  def provideMutator(config: LanguageMutatorConfig, options: InstrumenterOptions): LanguageMutator[? <: AST] =
+    languageProvider.provideMutator(config, options).asInstanceOf[LanguageMutator[? <: AST]]
 }
 
 object SupportedLanguageMutators {
@@ -19,11 +22,15 @@ object SupportedLanguageMutators {
     SupportedProvider("scala", "scala", "scala", new ScalaMutatorProvider)
   )
 
-  def supportedMutators(configs: Map[String, LanguageMutatorConfig], options: InstrumenterOptions): Map[String, LanguageMutator[? <: AST]] = {
+  def supportedMutators(
+      configs: Map[String, LanguageMutatorConfig],
+      options: InstrumenterOptions
+  ): Map[String, LanguageMutator[? <: AST]] = {
     val default = new LanguageMutatorConfig(new java.util.HashSet())
-    supportedProviders.map(
-      provider =>
-        provider.extension -> provider.provideMutator(configs.getOrElse(provider.name, default), options))
+    supportedProviders
+      .map(provider =>
+        provider.extension -> provider.provideMutator(configs.getOrElse(provider.name, default), options)
+      )
       .toMap
   }
 

--- a/stryker4jvm/src/main/scala/stryker4jvm/mutants/SupportedLanguageMutators.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/mutants/SupportedLanguageMutators.scala
@@ -1,19 +1,32 @@
 package stryker4jvm.mutants
 
-import stryker4jvm.core.model.LanguageMutator
-import stryker4jvm.core.model.AST
-import stryker4jvm.mutator.kotlin.KotlinMutator
+import stryker4jvm.core.config.LanguageMutatorConfig
+import stryker4jvm.core.model.{AST, InstrumenterOptions, LanguageMutator}
+import stryker4jvm.core.model.languagemutator.LanguageMutatorProvider
+import stryker4jvm.mutator.kotlin.KotlinMutatorProvider
+import stryker4jvm.mutator.scala.ScalaMutatorProvider
 
-case class SupportedMutator(directory: String, extension: String, languageMutator: LanguageMutator[? <: AST])
+case class SupportedProvider(name: String, directory: String, extension: String, languageProvider: LanguageMutatorProvider) {
+  def provideMutator(
+                      config: LanguageMutatorConfig,
+                      options: InstrumenterOptions):
+  LanguageMutator[? <: AST] = languageProvider.provideMutator(config, options).asInstanceOf[LanguageMutator[? <: AST]]
+}
 
 object SupportedLanguageMutators {
-  val supportedMutators: Array[SupportedMutator] = Array(
-    SupportedMutator("kotlin", "kt", new KotlinMutator())
+  val supportedProviders: Seq[SupportedProvider] = Seq(
+    SupportedProvider("kotlin", "kotlin", "kt", new KotlinMutatorProvider),
+    SupportedProvider("scala", "scala", "scala", new ScalaMutatorProvider)
   )
 
-  def languageRouter: Map[String, LanguageMutator[? <: AST]] =
-    supportedMutators.map(mutator => mutator.extension -> mutator.languageMutator).toMap
+  def supportedMutators(configs: Map[String, LanguageMutatorConfig], options: InstrumenterOptions): Map[String, LanguageMutator[? <: AST]] = {
+    val default = new LanguageMutatorConfig(new java.util.HashSet())
+    supportedProviders.map(
+      provider =>
+        provider.extension -> provider.provideMutator(configs.getOrElse(provider.name, default), options))
+      .toMap
+  }
 
   def mutatesFileSources: Seq[String] =
-    supportedMutators.map(mutator => s"**/main/${mutator.directory}/**.${mutator.extension}")
+    supportedProviders.map(mutator => s"**/main/${mutator.directory}/**.${mutator.extension}")
 }

--- a/stryker4jvm/src/main/scala/stryker4jvm/run/Stryker4jvmRunner.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/run/Stryker4jvmRunner.scala
@@ -25,9 +25,9 @@ import sttp.model.HeaderNames
 abstract class Stryker4jvmRunner(implicit log: Logger) {
   def run(): IO[ScoreStatus] = {
     implicit val config: Config = ConfigReader.readConfig()
-    SupportedLanguageMutators.languageRouter.values.foreach(mutator =>
-      mutator.setLanguageConfig(config.asLanguageMutatorConfig)
-    )
+    // no definition for kotlin configs yet! todo
+    val scalaConfig = config.asLanguageMutatorConfig
+    val languageMutatorConfigs = Map("scala" -> scalaConfig)
 
     val createTestRunnerPool = (path: Path) => resolveTestRunners(path).map(ResourcePool(_))
     val reporter = new AggregateReporter(resolveReporters())
@@ -35,7 +35,7 @@ abstract class Stryker4jvmRunner(implicit log: Logger) {
     val stryker4jvm = new Stryker4jvm(
       resolveMutatesFileSource,
       new Mutator(
-        SupportedLanguageMutators.languageRouter
+        SupportedLanguageMutators.supportedMutators(languageMutatorConfigs, instrumenterOptions)
       ),
       new MutantRunner(createTestRunnerPool, resolveFilesFileSource, new RollbackHandler(), reporter),
       reporter

--- a/stryker4jvm/src/main/scala/stryker4jvm/run/Stryker4jvmRunner.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/run/Stryker4jvmRunner.scala
@@ -6,12 +6,12 @@ import fs2.io.file.Path
 import stryker4jvm.Stryker4jvm
 import stryker4jvm.config.{Config, ConfigReader, Console, Dashboard, Html, Json}
 import stryker4jvm.core.logging.Logger
+import stryker4jvm.core.model.Instrumenter.InstrumenterOptions
 import stryker4jvm.extensions.Stryker4jvmCoreConversions.*
 import stryker4jvm.files.{ConfigFilesResolver, DiskFileIO, FilesFileResolver, GlobFileResolver, MutatesFileResolver}
 import stryker4jvm.logging.SttpLogWrapper
 import stryker4jvm.model.CompilerErrMsg
 import stryker4jvm.mutants.{Mutator, SupportedLanguageMutators}
-import stryker4jvm.mutator.scala.mutants.tree.InstrumenterOptions
 import stryker4jvm.reporting.*
 import stryker4jvm.reporting.dashboard.DashboardConfigProvider
 import stryker4jvm.reporting.reporters.*
@@ -24,7 +24,6 @@ import sttp.model.HeaderNames
 
 abstract class Stryker4jvmRunner(implicit log: Logger) {
   def run(): IO[ScoreStatus] = {
-    // todo: scala mutator still uses their own config object so this implicit won't work
     implicit val config: Config = ConfigReader.readConfig()
     SupportedLanguageMutators.languageRouter.values.foreach(mutator =>
       mutator.setLanguageConfig(config.asLanguageMutatorConfig)

--- a/stryker4jvm/src/main/scala/stryker4jvm/run/Stryker4jvmRunner.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/run/Stryker4jvmRunner.scala
@@ -6,7 +6,7 @@ import fs2.io.file.Path
 import stryker4jvm.Stryker4jvm
 import stryker4jvm.config.{Config, ConfigReader, Console, Dashboard, Html, Json}
 import stryker4jvm.core.logging.Logger
-import stryker4jvm.core.model.Instrumenter.InstrumenterOptions
+import stryker4jvm.core.model.InstrumenterOptions
 import stryker4jvm.extensions.Stryker4jvmCoreConversions.*
 import stryker4jvm.files.{ConfigFilesResolver, DiskFileIO, FilesFileResolver, GlobFileResolver, MutatesFileResolver}
 import stryker4jvm.logging.SttpLogWrapper


### PR DESCRIPTION
#### What it does

Fixed compilation issues in stryker4jvm due to dependency issues and moving of classes.
Created a provider that works as a factory method for language mutators.

#### How it works

Created InstrumenterOptions enum in core to signal how a languagemutator can find the current active mutation during runtime.
Created LanguageMutatorProvider which serves as factory method for creating language mutators. This provider takes the configuration and instrumenter options. This in turn means that I have removed the config from the interfaces in core (collect, parse, instrument).
Created KotlinMutatorProvider and stubbed ScalaMutatorProvider.
Modfiied SupportMutators in stryker4jvm to work with providers instead.
