### PR TITLE
Invalid file extensions

### DIFF
--- a/stryker4jvm/src/main/scala/stryker4jvm/exception/InvalidFileTypeException.scala
+++ b/stryker4jvm/src/main/scala/stryker4jvm/exception/InvalidFileTypeException.scala
@@ -1,0 +1,9 @@
+package stryker4jvm.exception
+
+import fs2.io.file.Path
+import stryker4jvm.core.exception.Stryker4jvmException
+
+final case class InvalidFileTypeException(path: Path)
+    extends Stryker4jvmException(
+      s"File $path with extension ${path.extName} does not have a supported Language Mutator."
+    )

--- a/stryker4jvm/src/test/resources/mockFiles/simple.test
+++ b/stryker4jvm/src/test/resources/mockFiles/simple.test
@@ -1,0 +1,6 @@
+Hello world
+not a mutator
+
+1 does not get mutated
+Another mutator
+Mut4t0r

--- a/stryker4jvm/src/test/scala/stryker4jvm/mutants/LanguageMutatorTest.scala
+++ b/stryker4jvm/src/test/scala/stryker4jvm/mutants/LanguageMutatorTest.scala
@@ -1,0 +1,77 @@
+package stryker4jvm.mutants
+
+import stryker4jvm.core.model.{AST, MutantWithId, MutatedCode}
+import stryker4jvm.scalatest.FileUtil
+import stryker4jvm.testutil.{MockAST, Stryker4jvmSuite, TestLanguageMutator}
+
+import scala.collection.JavaConverters.*
+import scala.io.Source
+
+class LanguageMutatorTest extends Stryker4jvmSuite {
+  val path = FileUtil.getResource("mockFiles/simple.test").toNioPath
+
+  describe("Mock Parser") {
+    it("Should parse and give all lines") {
+      val mutator = new TestLanguageMutator()
+      val ast = mutator.parse(path)
+      val bufferedSource = Source.fromFile(path.toFile)
+      val lines = bufferedSource.getLines().toArray
+      bufferedSource.close()
+      val expected = lines.map(line => new MockAST(line, Array.empty))
+      assert(expected.length == ast.children.length)
+    }
+
+    it("Should have the correct lines") {
+      val mutator = new TestLanguageMutator()
+      val ast = mutator.parse(path)
+      val bufferedSource = Source.fromFile(path.toFile)
+      val lines = bufferedSource.getLines().toArray
+      bufferedSource.close()
+      assert(ast.contents == "")
+      for ((exp, act) <- lines.zip(ast.children)) {
+        assert(exp.equals(act.contents) && act.children.isEmpty)
+      }
+    }
+  }
+
+  describe("Mock Collector") {
+    it("Should not collect any empty lines") {
+      val mutator = new TestLanguageMutator()
+      val ast = mutator.parse(path)
+      val collected = mutator.collect(ast)
+      collected.mutations.keySet().forEach(tree => assert(!tree.contents.equals("")))
+    }
+
+    it("Should collect all lines with a capital") {
+      val mutator = new TestLanguageMutator()
+      val ast = mutator.parse(path)
+      val collected = mutator.collect(ast)
+      collected.mutations.keySet().forEach(tree => assert(tree.contents.charAt(0).isUpper))
+    }
+  }
+
+  describe("Mock instrumenter") {
+    it("Should add \"Mutated:\" to mutant") {
+      val mutator = new TestLanguageMutator()
+      val ast = mutator.parse(path)
+      val bufferedSource = Source.fromFile(path.toFile)
+      val lines = bufferedSource.getLines().toArray
+      bufferedSource.close()
+      val collected = mutator.collect(ast)
+      val mutantsWithId = collected.mutations.asScala.map{case (tree, mutations) => {
+        val mutantWithId = mutations.asScala
+          .map(mutatedCode => new MutantWithId(0, mutatedCode.asInstanceOf[MutatedCode[AST]])).asJava
+        (tree.asInstanceOf[AST], mutantWithId)
+      }}.asJava
+      val instrumented = mutator.instrument(ast, mutantsWithId)
+      assert(ast != instrumented)
+      for (i <- lines.indices) {
+        val isMutant = lines(i).nonEmpty && lines(i).charAt(0).isUpper
+        if (isMutant) {
+          assert(instrumented.children(i).contents.startsWith("Mutated:"))
+        }
+      }
+
+    }
+  }
+}

--- a/stryker4jvm/src/test/scala/stryker4jvm/mutants/LanguageMutatorTest.scala
+++ b/stryker4jvm/src/test/scala/stryker4jvm/mutants/LanguageMutatorTest.scala
@@ -28,9 +28,8 @@ class LanguageMutatorTest extends Stryker4jvmSuite {
       val lines = bufferedSource.getLines().toArray
       bufferedSource.close()
       assert(ast.contents == "")
-      for ((exp, act) <- lines.zip(ast.children)) {
+      for ((exp, act) <- lines.zip(ast.children))
         assert(exp.equals(act.contents) && act.children.isEmpty)
-      }
     }
   }
 
@@ -58,11 +57,12 @@ class LanguageMutatorTest extends Stryker4jvmSuite {
       val lines = bufferedSource.getLines().toArray
       bufferedSource.close()
       val collected = mutator.collect(ast)
-      val mutantsWithId = collected.mutations.asScala.map{case (tree, mutations) => {
+      val mutantsWithId = collected.mutations.asScala.map { case (tree, mutations) =>
         val mutantWithId = mutations.asScala
-          .map(mutatedCode => new MutantWithId(0, mutatedCode.asInstanceOf[MutatedCode[AST]])).asJava
+          .map(mutatedCode => new MutantWithId(0, mutatedCode.asInstanceOf[MutatedCode[AST]]))
+          .asJava
         (tree.asInstanceOf[AST], mutantWithId)
-      }}.asJava
+      }.asJava
       val instrumented = mutator.instrument(ast, mutantsWithId)
       assert(ast != instrumented)
       for (i <- lines.indices) {

--- a/stryker4jvm/src/test/scala/stryker4jvm/mutants/MutatorTest.scala
+++ b/stryker4jvm/src/test/scala/stryker4jvm/mutants/MutatorTest.scala
@@ -3,142 +3,160 @@ package stryker4jvm.mutants
 import fansi.Color.*
 import fs2.Stream
 import stryker4jvm.config.Config
+import stryker4jvm.exception.InvalidFileTypeException
 import stryker4jvm.scalatest.{FileUtil, LogMatchers}
-import stryker4jvm.testutil.Stryker4jvmIOSuite
+import stryker4jvm.testutil.{Stryker4jvmIOSuite, TestLanguageMutator}
 
 import scala.meta.*
 
 class MutatorTest extends Stryker4jvmIOSuite with LogMatchers {
-  /* TODO make it compile
-    describe("run") {
+  val testLanguageMutator = new TestLanguageMutator()
+
+  describe("go") {
+    it("Should not give an error for correct files") {
       implicit val conf: Config = Config.default
-      val sut = new Mutator(
-        SupportedLanguageMutators.languageRouter
-      )
-      // TODO MutatorTest tests
-
-      it("should return a single AST with changed pattern match") {
-        val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
-
-        sut.go(files).asserting { case (_, result) =>
-          val expected = """object Foo {
-                           |  def bar = _root_.stryker4s.activeMutation match {
-                           |    case 0 =>
-                           |      15 >= 14
-                           |    case 1 =>
-                           |      15 < 14
-                           |    case 2 =>
-                           |      15 == 14
-                           |    case _ if _root_.stryker4s.coverage.coverMutant(0, 1, 2) =>
-                           |      15 > 14
-                           |  }
-                           |  def foobar = _root_.stryker4s.activeMutation match {
-                           |    case 3 =>
-                           |      ""
-                           |    case _ if _root_.stryker4s.coverage.coverMutant(3) =>
-                           |      s"${bar}foo"
-                           |  }
-                           |}""".stripMargin.parse[Source].get
-
-          assert(result.loneElement.mutatedSource.equals(expected), result.loneElement.mutatedSource)
-        }
-      }
-
-      it("should run go") {
-        val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
-
-        sut.go(files).asserting { case (_, result) =>
-          val expected = """object Foo {
-                           |  def bar = _root_.stryker4s.activeMutation match {
-                           |    case 0 =>
-                           |      15 >= 14
-                           |    case 1 =>
-                           |      15 < 14
-                           |    case 2 =>
-                           |      15 == 14
-                           |    case _ if _root_.stryker4s.coverage.coverMutant(0, 1, 2) =>
-                           |      15 > 14
-                           |  }
-                           |  def foobar = _root_.stryker4s.activeMutation match {
-                           |    case 3 =>
-                           |      ""
-                           |    case _ if _root_.stryker4s.coverage.coverMutant(3) =>
-                           |      s"${bar}foo"
-                           |  }
-                           |}""".stripMargin.parse[Source].get
-          assert(result.loneElement.mutatedSource.equals(expected), result.loneElement.mutatedSource)
-        }
-      }
-    }
-    describe("logs") {
-
-      it("should log the amount of mutants found") {
-        implicit val conf: Config = Config.default
-        val sut = new Mutator(
-          SupportedLanguageMutators.languageRouter
-        )
-        val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
-
-        sut.go(files).asserting { _ =>
-          s"Found ${Cyan("1")} file(s) to be mutated." shouldBe loggedAsInfo
-          s"Found ${Cyan("1")} file(s) to be mutated. Of which" should not be loggedAsInfo
-          s"${Cyan("4")} mutant(s) generated" shouldBe loggedAsInfo
-        }
-      }
-
-      it("should log the amount of excluded mutants") {
-        implicit val conf: Config = Config.default.copy(excludedMutations = Set("EqualityOperator"))
-        val sut = new Mutator(
-          SupportedLanguageMutators.languageRouter
-        )
-        val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
-
-        sut.go(files).asserting { _ =>
-          s"Found ${Cyan("1")} file(s) to be mutated." shouldBe loggedAsInfo
-          s"${Cyan("4")} mutant(s) generated. Of which ${LightRed("3")} mutant(s) are excluded." shouldBe loggedAsInfo
-          "Files to be mutated are found, but no mutations were found in those files." should not be loggedAsInfo
-          "If this is not intended, please check your configuration and try again." should not be loggedAsInfo
-        }
-      }
-
-      it("should log a warning if no mutants are found") {
-        implicit val conf: Config = Config.default.copy(excludedMutations = Set("EqualityOperator"))
-        val sut = new Mutator(
-          SupportedLanguageMutators.languageRouter
-        )
-        val files = Stream(FileUtil.getResource("fileTests/filledDir/src/main/scala/package/someFile.scala"))
-
-        sut.go(files).asserting { _ =>
-          s"Found ${Cyan("1")} file(s) to be mutated." shouldBe loggedAsInfo
-          s"${Cyan("0")} mutant(s) generated." shouldBe loggedAsInfo
-          "Files to be mutated are found, but no mutations were found in those files." shouldBe loggedAsInfo
-          "If this is not intended, please check your configuration and try again." shouldBe loggedAsInfo
-        }
-      }
-
-      it("should log if all mutations are excluded") {
-        implicit val conf: Config = Config.default.copy(excludedMutations = Set("EqualityOperator", "StringLiteral"))
-        val sut = new Mutator(
-          SupportedLanguageMutators.languageRouter
-        )
-        val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
-
-        sut.go(files).asserting { _ =>
-          s"Found ${Cyan("1")} file(s) to be mutated." shouldBe loggedAsInfo
-          s"${Cyan("4")} mutant(s) generated. Of which ${LightRed("4")} mutant(s) are excluded." shouldBe loggedAsInfo
-          s"""All found mutations are excluded. Stryker4s will perform a dry-run without actually mutating anything.
-             |You can configure the `mutate` or `excluded-mutations` property in your configuration""".stripMargin shouldBe loggedAsWarning
-          "Files to be mutated are found, but no mutations were found in those files." should not be loggedAsInfo
-          "If this is not intended, please check your configuration and try again." should not be loggedAsInfo
-        }
-      }
+      val mutator = new Mutator(Map(".test" -> testLanguageMutator))
+      val files = Stream(FileUtil.getResource("mockFiles/simple.test"))
+      mutator.go(files).assertNoException
     }
 
+    it("Should give an exception for invalid file extensions") {
+      implicit val conf: Config = Config.default
+      val mutator = new Mutator(Map(".notTest" -> testLanguageMutator))
+      val files = Stream(FileUtil.getResource("mockFiles/simple.test"))
+      mutator.go(files).assertThrows[InvalidFileTypeException]
+    }
   }
 
-  final class IsEqualExtension(val thisTree: Tree) extends AnyVal {
+//    describe("run") {
+//      implicit val conf: Config = Config.default
+//      val sut = new Mutator(
+//        SupportedLanguageMutators.languageRouter
+//      )
+//      // TODO MutatorTest tests
+//
+//      it("should return a single AST with changed pattern match") {
+//        val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
+//
+//        sut.go(files).asserting { case (_, result) =>
+//          val expected = """object Foo {
+//                           |  def bar = _root_.stryker4s.activeMutation match {
+//                           |    case 0 =>
+//                           |      15 >= 14
+//                           |    case 1 =>
+//                           |      15 < 14
+//                           |    case 2 =>
+//                           |      15 == 14
+//                           |    case _ if _root_.stryker4s.coverage.coverMutant(0, 1, 2) =>
+//                           |      15 > 14
+//                           |  }
+//                           |  def foobar = _root_.stryker4s.activeMutation match {
+//                           |    case 3 =>
+//                           |      ""
+//                           |    case _ if _root_.stryker4s.coverage.coverMutant(3) =>
+//                           |      s"${bar}foo"
+//                           |  }
+//                           |}""".stripMargin.parse[Source].get
+//
+//          assert(result.loneElement.mutatedSource.equals(expected), result.loneElement.mutatedSource)
+//        }
+//      }
+//
+//      it("should run go") {
+//        val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
+//
+//        sut.go(files).asserting { case (_, result) =>
+//          val expected = """object Foo {
+//                           |  def bar = _root_.stryker4s.activeMutation match {
+//                           |    case 0 =>
+//                           |      15 >= 14
+//                           |    case 1 =>
+//                           |      15 < 14
+//                           |    case 2 =>
+//                           |      15 == 14
+//                           |    case _ if _root_.stryker4s.coverage.coverMutant(0, 1, 2) =>
+//                           |      15 > 14
+//                           |  }
+//                           |  def foobar = _root_.stryker4s.activeMutation match {
+//                           |    case 3 =>
+//                           |      ""
+//                           |    case _ if _root_.stryker4s.coverage.coverMutant(3) =>
+//                           |      s"${bar}foo"
+//                           |  }
+//                           |}""".stripMargin.parse[Source].get
+//          assert(result.loneElement.mutatedSource.equals(expected), result.loneElement.mutatedSource)
+//        }
+//      }
+//    }
+//    describe("logs") {
+//
+//      it("should log the amount of mutants found") {
+//        implicit val conf: Config = Config.default
+//        val sut = new Mutator(
+//          SupportedLanguageMutators.languageRouter
+//        )
+//        val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
+//
+//        sut.go(files).asserting { _ =>
+//          s"Found ${Cyan("1")} file(s) to be mutated." shouldBe loggedAsInfo
+//          s"Found ${Cyan("1")} file(s) to be mutated. Of which" should not be loggedAsInfo
+//          s"${Cyan("4")} mutant(s) generated" shouldBe loggedAsInfo
+//        }
+//      }
+//
+//      it("should log the amount of excluded mutants") {
+//        implicit val conf: Config = Config.default.copy(excludedMutations = Set("EqualityOperator"))
+//        val sut = new Mutator(
+//          SupportedLanguageMutators.languageRouter
+//        )
+//        val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
+//
+//        sut.go(files).asserting { _ =>
+//          s"Found ${Cyan("1")} file(s) to be mutated." shouldBe loggedAsInfo
+//          s"${Cyan("4")} mutant(s) generated. Of which ${LightRed("3")} mutant(s) are excluded." shouldBe loggedAsInfo
+//          "Files to be mutated are found, but no mutations were found in those files." should not be loggedAsInfo
+//          "If this is not intended, please check your configuration and try again." should not be loggedAsInfo
+//        }
+//      }
+//
+//      it("should log a warning if no mutants are found") {
+//        implicit val conf: Config = Config.default.copy(excludedMutations = Set("EqualityOperator"))
+//        val sut = new Mutator(
+//          SupportedLanguageMutators.languageRouter
+//        )
+//        val files = Stream(FileUtil.getResource("fileTests/filledDir/src/main/scala/package/someFile.scala"))
+//
+//        sut.go(files).asserting { _ =>
+//          s"Found ${Cyan("1")} file(s) to be mutated." shouldBe loggedAsInfo
+//          s"${Cyan("0")} mutant(s) generated." shouldBe loggedAsInfo
+//          "Files to be mutated are found, but no mutations were found in those files." shouldBe loggedAsInfo
+//          "If this is not intended, please check your configuration and try again." shouldBe loggedAsInfo
+//        }
+//      }
+//
+//      it("should log if all mutations are excluded") {
+//        implicit val conf: Config = Config.default.copy(excludedMutations = Set("EqualityOperator", "StringLiteral"))
+//        val sut = new Mutator(
+//          SupportedLanguageMutators.languageRouter
+//        )
+//        val files = Stream(FileUtil.getResource("scalaFiles/simpleFile.scala"))
+//
+//        sut.go(files).asserting { _ =>
+//          s"Found ${Cyan("1")} file(s) to be mutated." shouldBe loggedAsInfo
+//          s"${Cyan("4")} mutant(s) generated. Of which ${LightRed("4")} mutant(s) are excluded." shouldBe loggedAsInfo
+//          s"""All found mutations are excluded. Stryker4s will perform a dry-run without actually mutating anything.
+//             |You can configure the `mutate` or `excluded-mutations` property in your configuration""".stripMargin shouldBe loggedAsWarning
+//          "Files to be mutated are found, but no mutations were found in those files." should not be loggedAsInfo
+//          "If this is not intended, please check your configuration and try again." should not be loggedAsInfo
+//        }
+//      }
+//    }
 
-    /** Structural equality for Trees
-   */
-    final def isEqual(other: Tree): Boolean = thisTree == other || thisTree.structure == other.structure*/
+}
+
+final class IsEqualExtension(val thisTree: Tree) extends AnyVal {
+
+  /** Structural equality for Trees
+    */
+  final def isEqual(other: Tree): Boolean = thisTree == other || thisTree.structure == other.structure
 }

--- a/stryker4jvm/src/test/scala/stryker4jvm/testutil/TestLanguageMutator.scala
+++ b/stryker4jvm/src/test/scala/stryker4jvm/testutil/TestLanguageMutator.scala
@@ -1,7 +1,17 @@
 package stryker4jvm.testutil
 
 import stryker4jvm.core.model.elements.{Location, Position}
-import stryker4jvm.core.model.{AST, CollectedMutants, Collector, Instrumenter, LanguageMutator, MutantMetaData, MutantWithId, MutatedCode, Parser}
+import stryker4jvm.core.model.{
+  AST,
+  CollectedMutants,
+  Collector,
+  Instrumenter,
+  LanguageMutator,
+  MutantMetaData,
+  MutantWithId,
+  MutatedCode,
+  Parser
+}
 
 import java.nio.file.Path
 import java.util
@@ -16,8 +26,8 @@ class MockAST(val contents: String, val children: Array[MockAST]) extends AST {
   override def equals(other: Any): Boolean = other match {
     case that: MockAST =>
       (that canEqual this) &&
-        contents == that.contents &&
-        children == that.children
+      contents == that.contents &&
+      children == that.children
     case _ => false
   }
 
@@ -39,35 +49,44 @@ class TestParser extends Parser[MockAST] {
 class TestCollector extends Collector[MockAST] {
   override def collect(t: MockAST): CollectedMutants[MockAST] = {
     val mutations =
-      t.children
-        .zipWithIndex
-        .filter{case (ast, _) => {
-        val contents = ast.contents
-        contents.nonEmpty && contents.charAt(0).isUpper
-      }}
-      .map{case (ast, i) => {
-        val oldContents = ast.contents
-        val newContents = "Mutated: " + oldContents
-        val mutatedCode: MutatedCode[MockAST] = new MutatedCode(new MockAST(newContents, Array.empty),
-          new MutantMetaData(oldContents, newContents, "TestMutator",
-            new Location(new Position(i, 0), new Position(i, 0))))
-        (ast -> List(mutatedCode).asJava)
-      }}.toMap
+      t.children.zipWithIndex
+        .filter { case (ast, _) =>
+          val contents = ast.contents
+          contents.nonEmpty && contents.charAt(0).isUpper
+        }
+        .map { case (ast, i) =>
+          val oldContents = ast.contents
+          val newContents = "Mutated: " + oldContents
+          val mutatedCode: MutatedCode[MockAST] = new MutatedCode(
+            new MockAST(newContents, Array.empty),
+            new MutantMetaData(
+              oldContents,
+              newContents,
+              "TestMutator",
+              new Location(new Position(i, 0), new Position(i, 0))
+            )
+          )
+          ast -> List(mutatedCode).asJava
+        }
+        .toMap
     new CollectedMutants[MockAST](List.empty.asJava, mutations.asJava)
   }
 }
 
 class TestInstrumenter extends Instrumenter[MockAST] {
   override def instrument(ast: MockAST, map: util.Map[MockAST, util.List[MutantWithId[MockAST]]]): MockAST = {
-    val instrumented = ast.children.map(child => map.asScala.get(child) match {
-      case Some(mutated) => mutated.asScala.head.mutatedCode.mutatedStatement
-      case None => child
-    })
+    val instrumented = ast.children.map(child =>
+      map.asScala.get(child) match {
+        case Some(mutated) => mutated.asScala.head.mutatedCode.mutatedStatement
+        case None          => child
+      }
+    )
     new MockAST(ast.contents, instrumented)
   }
 }
 
-class TestLanguageMutator(parser: TestParser = new TestParser(),
-                          collector: TestCollector = new TestCollector(),
-                          instrumenter: TestInstrumenter = new TestInstrumenter()
+class TestLanguageMutator(
+    parser: TestParser = new TestParser(),
+    collector: TestCollector = new TestCollector(),
+    instrumenter: TestInstrumenter = new TestInstrumenter()
 ) extends LanguageMutator[MockAST](parser, collector, instrumenter)

--- a/stryker4jvm/src/test/scala/stryker4jvm/testutil/TestLanguageMutator.scala
+++ b/stryker4jvm/src/test/scala/stryker4jvm/testutil/TestLanguageMutator.scala
@@ -1,0 +1,73 @@
+package stryker4jvm.testutil
+
+import stryker4jvm.core.model.elements.{Location, Position}
+import stryker4jvm.core.model.{AST, CollectedMutants, Collector, Instrumenter, LanguageMutator, MutantMetaData, MutantWithId, MutatedCode, Parser}
+
+import java.nio.file.Path
+import java.util
+import scala.collection.JavaConverters.*
+import scala.io.Source
+
+class MockAST(val contents: String, val children: Array[MockAST]) extends AST {
+  override def syntax(): String = s"$contents, ${children.mkString("{", ", ", "}")}"
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[MockAST]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: MockAST =>
+      (that canEqual this) &&
+        contents == that.contents &&
+        children == that.children
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(contents, children)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
+}
+
+class TestParser extends Parser[MockAST] {
+  override def parse(path: Path): MockAST = {
+    val bufferedSource = Source.fromFile(path.toFile)
+    val result = new MockAST("", bufferedSource.getLines().map(new MockAST(_, Array.empty)).toArray)
+    bufferedSource.close()
+    result
+  }
+}
+
+class TestCollector extends Collector[MockAST] {
+  override def collect(t: MockAST): CollectedMutants[MockAST] = {
+    val mutations =
+      t.children
+        .zipWithIndex
+        .filter{case (ast, _) => {
+        val contents = ast.contents
+        contents.nonEmpty && contents.charAt(0).isUpper
+      }}
+      .map{case (ast, i) => {
+        val oldContents = ast.contents
+        val newContents = "Mutated: " + oldContents
+        val mutatedCode: MutatedCode[MockAST] = new MutatedCode(new MockAST(newContents, Array.empty),
+          new MutantMetaData(oldContents, newContents, "TestMutator",
+            new Location(new Position(i, 0), new Position(i, 0))))
+        (ast -> List(mutatedCode).asJava)
+      }}.toMap
+    new CollectedMutants[MockAST](List.empty.asJava, mutations.asJava)
+  }
+}
+
+class TestInstrumenter extends Instrumenter[MockAST] {
+  override def instrument(ast: MockAST, map: util.Map[MockAST, util.List[MutantWithId[MockAST]]]): MockAST = {
+    val instrumented = ast.children.map(child => map.asScala.get(child) match {
+      case Some(mutated) => mutated.asScala.head.mutatedCode.mutatedStatement
+      case None => child
+    })
+    new MockAST(ast.contents, instrumented)
+  }
+}
+
+class TestLanguageMutator(parser: TestParser = new TestParser(),
+                          collector: TestCollector = new TestCollector(),
+                          instrumenter: TestInstrumenter = new TestInstrumenter()
+) extends LanguageMutator[MockAST](parser, collector, instrumenter)


### PR DESCRIPTION
Add an exception when a file does not have the proper extension.
Should not be necessary for default config, but with a custom file filter this could happen.
Also contains a new test for Mutator using the new mock language