### PR TITLE
QA updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,37 +3,6 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  compile:
-    name: Test compilation on JDK ${{matrix.java-version}} (${{matrix.os}})
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version: [15]
-        os: ['ubuntu-latest', 'windows-latest']
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-        name: Check out repository
-      - uses: actions/setup-java@v3
-        name: Setup java
-        with:
-          distribution: 'corretto'
-          java-version: ${{ matrix.java-version }}
-          cache: 'sbt'
-      - name: Build core with Maven
-        working-directory: ./stryker4jvm-core
-        run: mvn clean install
-      - name: Setup Gradle and build Kotlin Mutator
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: 6.9.1
-          build-root-directory: ./stryker4jvm-mutator-kotlin
-          arguments: |
-              clean build
-              publishToMavenLocal
-      - name: Compile Stryker4JVM
-        run: sbt compile
-
   test:
     name: Run tests on JDK ${{matrix.java-version}} (${{matrix.os}})
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
           arguments: |
             clean build
             publishToMavenLocal
-      - name: Run tests
-        run: sbt test
+      - name: Run tests with coverage
+        run: sbt coverage test coverageAggregate
 
   sbt-scripted:
     name: sbt plugin scripted tests

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -33,8 +33,38 @@ jobs:
             publishToMavenLocal
       - name: Create Stryker4jvm config
         run: echo 'stryker4jvm{reporters=["console","dashboard"],base-dir="core",dashboard.module="core"}' > stryker4jvm.conf
-      - name: Run Stryker4jvm
+      - name: Run stryker on Stryker4jvm
         run: sbt 'project stryker4jvm; stryker'
+        env:
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+
+  mutator-scala:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Fetch all commits, used by sbt-dynver plugin to determine version
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 15
+          cache: 'sbt'
+      - name: Build core with Maven
+        working-directory: ./stryker4jvm-core
+        run: mvn clean install
+      - name: Setup Gradle and build Kotlin Mutator
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 6.9.1
+          build-root-directory: ./stryker4jvm-mutator-kotlin
+          arguments: |
+            clean build
+            publishToMavenLocal
+      - name: Create Stryker4jvm config
+        run: echo 'stryker4jvm{reporters=["console","dashboard"],base-dir="stryker4jvm-mutator-scala",dashboard.module="stryker4jvm-mutator-scala"}' > stryker4jvm.conf
+      - name: Run stryker on Stryker4jvm
+        run: sbt 'project stryker4jvm-mutator-scala; stryker'
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
 
@@ -63,7 +93,7 @@ jobs:
             publishToMavenLocal
       - name: Create Stryker4jvm config
         run: echo 'stryker4jvm{reporters=["console","dashboard"],base-dir="command-runner",dashboard.module="command-runner"}' > stryker4jvm.conf
-      - name: Run Stryker4jvm
+      - name: Run stryker on the command runner
         run: sbt 'project stryker4jvm-command-runner; stryker'
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
@@ -93,10 +123,9 @@ jobs:
             clean build
             publishToMavenLocal
       - name: Publish Stryker4jvm maven deps locally
-        run: sbt 'publishM2Local'
+        run: sbt publishM2Local
       - name: Run Stryker4s maven plugin on Stryker4jvm-plugin-maven
-        run: |
-          cd stryker4jvm-plugin-maven
-          mvn -B --no-transfer-progress stryker4s:run
+        working-directory: ./stryker4jvm-plugin-maven
+        run: mvn -B --no-transfer-progress stryker4s:run
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/build.sbt
+++ b/build.sbt
@@ -60,11 +60,11 @@ lazy val sbtStryker4jvm = newProject("stryker4jvm-plugin-sbt", "stryker4jvm-plug
 lazy val sbtTestRunner = newProject("stryker4jvm-plugin-sbt-testrunner", "stryker4jvm-plugin-sbt-testrunner")
   .settings(sbtTestrunnerSettings)
   .dependsOn(stryker4jvmApi)
-  .jvmPlatform(scalaVersions = versions.fullCrossScalaVersions)
+  .jvmPlatform(scalaVersions = versions.crossScalaVersions)
 
 lazy val stryker4jvmApi = newProject("stryker4jvm-api", "stryker4jvm-api")
   .settings(apiSettings)
-  .jvmPlatform(scalaVersions = versions.fullCrossScalaVersions)
+  .jvmPlatform(scalaVersions = versions.crossScalaVersions)
 
 lazy val stryker4jvm = newProject("stryker4jvm", "stryker4jvm")
   .settings(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,10 +10,6 @@ object Dependencies {
       */
     val crossScalaVersions = Seq(scala213, scala212)
 
-    /** Fuller cross-versions (used for injected packages like stryker4s-api and sbt-stryker4s-testrunner)
-      */
-    val fullCrossScalaVersions = crossScalaVersions ++ Seq(scala3)
-
     // Test dependencies
     val catsEffectScalaTest = "1.5.0"
     val mockitoScala = "1.17.12"

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -1,5 +1,4 @@
 import scala.sys.process
-
 import sbt.Keys.*
 import sbt.*
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -5,6 +5,7 @@ import sbt.Keys.*
 import sbt.ScriptedPlugin.autoImport.{scriptedBufferLog, scriptedLaunchOpts}
 import sbt.*
 import sbtprotoc.ProtocPlugin.autoImport.PB
+import scoverage.ScoverageKeys.*
 
 object Settings {
   lazy val commonSettings: Seq[Setting[?]] = Seq(
@@ -117,7 +118,6 @@ object Settings {
   )
 
   lazy val buildInfo: Seq[Def.Setting[?]] = Seq(
-    // Fatal warnings only in CI turned off
     tpolecatReleaseModeEnvVar := "CI_RELEASE",
     tpolecatDefaultOptionsMode := DevMode,
     // Prevent version clash warnings when running Stryker4s on a locally-published on Stryker4s
@@ -142,6 +142,12 @@ object Settings {
     developers := List(
       Developer("hugo-vrijswijk", "Hugo", "", url("https://github.com/hugo-vrijswijk"))
     ),
-    versionScheme := Some("semver-spec")
+    versionScheme := Some("semver-spec"),
+
+    // scoverage settings
+    coverageExcludedPackages := ".*stryker4jvm\\.api.*;.*stryker4jvm\\.plugin.*;.*stryker4jvm\\.coverage.*;.*stryker4jvm\\.command.*",
+    coverageExcludedFiles := "stryker4jvm\\.package",
+    coverageFailOnMinimum := true,
+    coverageMinimumStmtTotal := 70
   )
 }

--- a/stryker4jvm-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaMutatorProvider.scala
+++ b/stryker4jvm-mutator-scala/src/main/scala/stryker4jvm/mutator/scala/ScalaMutatorProvider.scala
@@ -37,7 +37,7 @@ object ScalaMutatorProvider {
       return dialects.Scala211
     }
 
-    val defaultVersion = dialects.Scala213
+    val defaultVersion = dialects.Scala213Source3
     val scalaVersions = Map(
       List("scala212", "scala2.12", "2.12", "212") -> dialects.Scala212,
       List("scala212source3") -> dialects.Scala212Source3,

--- a/stryker4jvm-mutator-scala/src/test/scala/stryker4jvm/mutator/scala/ScalaMutatorProviderTest.scala
+++ b/stryker4jvm-mutator-scala/src/test/scala/stryker4jvm/mutator/scala/ScalaMutatorProviderTest.scala
@@ -65,7 +65,7 @@ class ScalaMutatorProviderTest extends Stryker4jvmSuite with BeforeAndAfterEach 
       val dialect = parseDialect(invalidDialect, logger)
       logger.logs.isEmpty shouldBe false
       logger.logs.head.contains("Unknown") shouldBe true
-      dialect shouldBe Scala213
+      dialect shouldBe Scala213Source3
     }
 
     val deprecatedVersions = List("scala211", "scala2.11", "2.11", "211")


### PR DESCRIPTION
#### What it does

Set standard scalaversion, 
add stryker on mutator-scala to pipeline
add coverage to CI tests
Remove sbt compile job from CI - compilation gets checked when running tests

#### How it works

Set standard scalaversion to 213Source3 as specified in documentation
